### PR TITLE
Added extractions & sourcetyping for pan:correlation events

### DIFF
--- a/install/Splunk_TA_paloalto/default/eventtypes.conf
+++ b/install/Splunk_TA_paloalto/default/eventtypes.conf
@@ -28,3 +28,6 @@ search = (sourcetype=pan_endpoint OR sourcetype=pan:endpoint) (log_subtype!="Pre
 
 [pan_endpoint]
 search = sourcetype=pan_endpoint OR sourcetype=pan:endpoint
+
+[pan_correlation]
+search = sourcetype=pan_correlation OR sourcetype=pan:correlation

--- a/install/Splunk_TA_paloalto/default/props.conf
+++ b/install/Splunk_TA_paloalto/default/props.conf
@@ -3,7 +3,7 @@ rename = pan:log
 pulldown_type = false
 # This first line adjusts PAN-OS 6.1.0 threat logs to revised 6.1.1+ format where the reportid field is at the end.
 SEDCMD-6_1_0 = s/^((?:[^,]+,){3}THREAT,(?:[^,]*,){27}".*",[^,]*,)(\d+),((?:[^,]*,){3})(\d+,0x\d+,(?:[^,]*,){14})$/\1\3\4,\2/
-TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hipmatch, pan_endpoint
+TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hipmatch, pan_endpoint, pan_correlation
 SHOULD_LINEMERGE = false
 MAX_TIMESTAMP_LOOKAHEAD = 44
 
@@ -15,7 +15,7 @@ pulldown_type = true
 SEDCMD-6_1_0 = s/^((?:[^,]+,){3}THREAT,(?:[^,]*,){27}".*",[^,]*,)(\d+),((?:[^,]*,){3})(\d+,0x\d+,(?:[^,]*,){14})$/\1\3\4,\2/
 SHOULD_LINEMERGE = false
 MAX_TIMESTAMP_LOOKAHEAD = 44
-TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hipmatch, pan_endpoint
+TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hipmatch, pan_endpoint, pan_correlation
 
 [pan_threat]
 rename = pan:threat
@@ -181,3 +181,5 @@ FIELDALIAS-signature        = cs2 as signature
 
 LOOKUP-endpoint_severity    = endpoint_severity_lookup severity_code OUTPUT severity
 
+[pan:correlation]
+REPORT-correlation = extract_correlation

--- a/install/Splunk_TA_paloalto/default/tags.conf
+++ b/install/Splunk_TA_paloalto/default/tags.conf
@@ -23,3 +23,7 @@ attack = enabled
 [eventtype=pan_malware_operations]
 malware = enabled
 operations = enabled
+
+[eventtype=pan_correlation]
+ids = enabled
+attack = enabled

--- a/install/Splunk_TA_paloalto/default/transforms.conf
+++ b/install/Splunk_TA_paloalto/default/transforms.conf
@@ -30,6 +30,11 @@ DEST_KEY = MetaData:Sourcetype
 REGEX = ^[^\|,]+ CEF:0\|
 FORMAT = sourcetype::pan:endpoint
 
+[pan_correlation]
+DEST_KEY = MetaData:Sourcetype
+REGEX = ^[^,]+,[^,]+,[^,]+,CORRELATION,
+FORMAT = sourcetype::pan:correlation
+
 #### field extractions
 
 [extract_threat]
@@ -51,6 +56,10 @@ FIELDS = "future_use1","receive_time","serial_number","type","log_subtype","futu
 [extract_hipmatch]
 DELIMS = ","
 FIELDS = "future_use1","receive_time","serial_number","type","log_subtype","future_use2","generated_time","src_user","virtual_system","host_name","os","src_ip","hip_name","hip_count","hip_type","future_use3","future_use4","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_host"
+
+[extract_correlation]
+DELIMS = ","
+FIELDS = "time","serial_number","dvc","log_subtype","future_use5","future_use6","future_use7","future_use8","future_use9","future_use10","src_user","src_ip","signature","signature_id","category","severity","message"
 
 [extract_threat_id]
 SOURCE_KEY = threat_name


### PR DESCRIPTION
I modified props.conf & transforms.conf and tried to follow the existing methodology to change sourcetype and extract fields.  I also made it CIM compatible by creating an eventtype called pan_correlation and tagging it appropriately.  There might be some datamodel work that I didn't get a chance to look into, and I didn't create or modify any dashboards.  This doesn't capture all of the correlation event information since they aren't being logged fully as far as I can tell.  I'll look into using the API to pull the events as a next step.
