### PR TITLE
Escape clickthru

### DIFF
--- a/default/data/ui/views/config_overview.xml
+++ b/default/data/ui/views/config_overview.xml
@@ -83,42 +83,42 @@
       <drilldown>
         <link field="_time">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` _time="$row._time$"
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` _time=$row._time|s$
         ]]>
         </link>
         <link field="result">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` result="$row.result$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` result=$row.result|s$&earliest=$earliest$&latest=$latest$
           ]]>
         </link>
         <link field="serial_number">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` serial_number="$row.serial_number$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` serial_number=$row.serial_number|s$&earliest=$earliest$&latest=$latest$
           ]]>
         </link>
         <link field="host">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` host="$row.host$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` host=$row.host|s$&earliest=$earliest$&latest=$latest$
           ]]>
         </link>
         <link field="admin">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` admin="$row.admin$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` admin=$row.admin|s$&earliest=$earliest$&latest=$latest$
           ]]>
         </link>
         <link field="host_name">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` host_name="$row.host_name$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` host_name=$row.host_name|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
         <link field="client">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` client="$row.client$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` client=$row.client|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
         <link field="configuration_path">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` configuration_path="$row.configuration_path$"
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_config` configuration_path=$row.configuration_path|s$
 	  ]]>
         </link>
       </drilldown>
@@ -147,7 +147,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` cmd="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` cmd=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	  ]]>
         </link>
       </drilldown>
@@ -173,7 +173,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` admin="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` admin=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	  ]]>
         </link>
       </drilldown>
@@ -201,7 +201,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -227,7 +227,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/content_overview.xml
+++ b/default/data/ui/views/content_overview.xml
@@ -100,7 +100,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	  ]]>
         </link>
       </drilldown>
@@ -142,7 +142,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type="$row.content_type$" app="$row.app$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type=$row.content_type|s$ app=$row.app|s$&earliest=$earliest$&latest=$latest$
       ]]>
         </link>
       </drilldown>
@@ -173,7 +173,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type="$row.content_type$" app="$row.app$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type=$row.content_type|s$ app=$row.app|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -205,7 +205,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type="$row.content_type$" category="$row.category$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` content_type=$row.content_type|s$ category=$row.category|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/data_filtering_overview.xml
+++ b/default/data/ui/views/data_filtering_overview.xml
@@ -72,7 +72,7 @@
       <drilldown>
         <link>
           <![CDATA[
-          /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` action="$click.name2$"  earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
+          /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` action=$click.name2|s$  earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
       ]]>
         </link>
       </drilldown>
@@ -98,7 +98,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app="$click.name2$"  earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$click.name2|s$  earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
 	  ]]>
         </link>
       </drilldown>
@@ -140,7 +140,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` threat_name="$row.threat_name$" action="$row.action$" src_ip="$row.src_ip$" app="$row.app$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` threat_name=$row.threat_name|s$ action=$row.action|s$ src_ip=$row.src_ip|s$ app=$row.app|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -171,7 +171,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` dest_ip="$row.Destination$" dest_location="$row.Location$" src_ip="$row.Source$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` dest_ip=$row.Destination|s$ dest_location=$row.Location|s$ src_ip=$row.Source|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/endpoint_overview.xml
+++ b/default/data/ui/views/endpoint_overview.xml
@@ -78,7 +78,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` log_subtype="$click.name2$" earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` log_subtype=$click.name2|s$ earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
 	        ]]>
           </link>
         </drilldown>
@@ -109,7 +109,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` severity="$click.name2$" earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` severity=$click.name2|s$ earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
 	        ]]>
           </link>
         </drilldown>
@@ -142,7 +142,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	        ]]>
           </link>
         </drilldown>
@@ -173,7 +173,7 @@
           <drilldown>
               <link>
                   <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	        ]]>
               </link>
           </drilldown>
@@ -204,7 +204,7 @@
           <drilldown>
               <link>
                   <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	        ]]>
               </link>
           </drilldown>
@@ -237,7 +237,7 @@
           <drilldown>
               <link>
                   <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	        ]]>
               </link>
           </drilldown>
@@ -268,7 +268,7 @@
           <drilldown>
               <link>
                   <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_endpoint` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	        ]]>
               </link>
           </drilldown>

--- a/default/data/ui/views/overview.xml
+++ b/default/data/ui/views/overview.xml
@@ -78,7 +78,7 @@
       <drilldown>
         <link>
           <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` sourcetype="pan:*" log_subtype="$click.name2$"&earliest=-5m&latest=now
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` sourcetype="pan:*" log_subtype=$click.name2|s$&earliest=-5m&latest=now
               ]]>
         </link>
       </drilldown>
@@ -98,7 +98,7 @@
       <drilldown>
         <link>
           <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` sourcetype="pan:traffic" app="$click.value$"&earliest=-5m&latest=now
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` sourcetype="pan:traffic" app=$click.value|s$&earliest=-5m&latest=now
               ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/saas_overview.xml
+++ b/default/data/ui/views/saas_overview.xml
@@ -108,7 +108,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	    ]]>
           </link>
         </drilldown>
@@ -128,32 +128,32 @@
         <drilldown>
           <link field="app">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app="$row.app$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$&earliest=$earliest$&latest=$latest$
           ]]>
           </link>
           <link field="app:category">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:category="$row.app:category$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:category=$row.app:category|s$&earliest=$earliest$&latest=$latest$
             ]]>
           </link>
           <link field="app:subcategory">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:subcategory="$row.app:subcategory$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
             ]]>
           </link>
           <link field="Sessions">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app="$row.app$" app:category="$row.app:category$" app:subcategory="$row.app:subcategory$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app:category|s$ app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
             ]]>
           </link>
           <link field="Vol in MB">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app="$row.app$" app:category="$row.app:category$" app:subcategory="$row.app:subcategory$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app:category|s$ app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
 	    ]]>
           </link>
           <link field="distribution">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app="$row.app$" app:category="$row.app:category$" app:subcategory="$row.app:subcategory$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app:category|s$ app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
 	    ]]>
           </link>
         </drilldown>
@@ -189,7 +189,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas="yes" | where $app:is_sanctioned_saas$=if("Sanctioned"="$click.value$","yes","no")&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas="yes" | where $app:is_sanctioned_saas$=if("Sanctioned"=$click.value|s$,"yes","no")&earliest=$earliest$&latest=$latest$
 	      ]]>
           </link>
         </drilldown>
@@ -207,7 +207,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas="yes" | where $app:is_sanctioned_saas$=if("Sanctioned"="$row.SaaS$","yes","no")&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas="yes" | where $app:is_sanctioned_saas$=if("Sanctioned"=$row.SaaS|s$,"yes","no")&earliest=$earliest$&latest=$latest$
 	        ]]>
           </link>
         </drilldown>
@@ -388,7 +388,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_file` app="$row.Application$"&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_file` app=$row.Application|s$&earliest=$earliest$&latest=$latest$
           ]]>
           </link>
         </drilldown>

--- a/default/data/ui/views/system_overview.xml
+++ b/default/data/ui/views/system_overview.xml
@@ -73,32 +73,32 @@
       <drilldown>
         <link field="_time">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` _time="$row._time$"
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` _time=$row._time|s$
         ]]>
         </link>
         <link field="serial_number">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` serial_number="$row.serial_number$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` serial_number=$row.serial_number|s$&earliest=$earliest$&latest=$latest$
           ]]>
         </link>
         <link field="description">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` description="$row.description$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` description=$row.description|s$&earliest=$earliest$&latest=$latest$
           ]]>
         </link>
         <link field="log_subtype">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` log_subtype="$row.log_subtype$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` log_subtype=$row.log_subtype|s$&earliest=$earliest$&latest=$latest$
           ]]>
         </link>
         <link field="severity">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` severity="$row.severity$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` severity=$row.severity|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
         <link field="event_id">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` event_id="$row.event_id$"
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` event_id=$row.event_id|s$
 	  ]]>
         </link>
       </drilldown>
@@ -127,7 +127,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` log_subtype="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` log_subtype=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	  ]]>
         </link>
       </drilldown>
@@ -153,7 +153,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` severity="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` severity=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/threat_overview.xml
+++ b/default/data/ui/views/threat_overview.xml
@@ -98,7 +98,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` severity="$click.name2$" earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` severity=$click.name2|s$ earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
 	  ]]>
         </link>
       </drilldown>
@@ -206,7 +206,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -232,7 +232,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -258,7 +258,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_threat` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/traffic_overview.xml
+++ b/default/data/ui/views/traffic_overview.xml
@@ -97,7 +97,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` protocol="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` protocol=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	  ]]>
         </link>
       </drilldown>
@@ -125,7 +125,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` app="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` app=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -151,7 +151,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` app="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` app=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -177,7 +177,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` src_ip="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` src_ip=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -205,7 +205,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` dest_port="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` dest_port=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -231,7 +231,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` dest_ip="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` dest_ip=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -257,7 +257,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` user="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` user=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -285,7 +285,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` dest_interface="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` dest_interface=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -311,7 +311,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` src_interface="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` src_interface=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/url_filtering_overview.xml
+++ b/default/data/ui/views/url_filtering_overview.xml
@@ -97,7 +97,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` app="$click.name2$" [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` app=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	  ]]>
         </link>
       </drilldown>
@@ -139,7 +139,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` user="$row.user$" app="$row.app$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` user=$row.user|s$ app=$row.app|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -170,12 +170,12 @@
       <drilldown>
         <link field="dest_hostname">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` dest_hostname="$row.dest_hostname$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` dest_hostname=$row.dest_hostname|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
         <link field="category">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` category="$row.category$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` category=$row.category|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/web_usage_report.xml
+++ b/default/data/ui/views/web_usage_report.xml
@@ -61,7 +61,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` dest_hostname="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` dest_hostname=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -87,7 +87,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -113,7 +113,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` $click.name$=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -146,17 +146,17 @@
       <drilldown>
         <link field="Action">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` action="$row.action$" category="$row.category$" dest_hostname="$row.dest_hostname$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` action=$row.action|s$ category=$row.category|s$ dest_hostname=$row.dest_hostname|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
         <link field="Category">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` category="$row.category$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` category=$row.category|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
         <link field="Hostname">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` dest_hostname="$row.dest_hostname$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_web_activity` dest_hostname=$row.dest_hostname|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>

--- a/default/data/ui/views/wildfire_overview.xml
+++ b/default/data/ui/views/wildfire_overview.xml
@@ -70,7 +70,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_wildfire` category="$click.name2$" earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_wildfire` category=$click.name2|s$ earliest=$click.value$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest]
 	  ]]>
         </link>
       </drilldown>
@@ -101,7 +101,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` dest_ip="$row.Destination IP$" misc="$row.Filename$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` dest_ip=$row.Destination IP|s$ misc=$row.Filename|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -170,12 +170,12 @@
         </link>
         <link field="WildFire Link">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` (sourcetype="pan:wildfire_report" (wildfire.id="$row.WildFire Report ID$" OR wildfire.report.id="$row.WildFire Report ID$")) OR (sourcetype="pan:threat" log_subtype="wildfire" report_id="$row.WildFire Report ID$")
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` (sourcetype="pan:wildfire_report" (wildfire.id=$row.WildFire Report ID|s$ OR wildfire.report.id=$row.WildFire Report ID|s$)) OR (sourcetype="pan:threat" log_subtype="wildfire" report_id=$row.WildFire Report ID|s$)
 	  ]]>
         </link>
         <link field="*">
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` src_ip="$row.Source$" dest_ip="$row.Dest IP$" dest_port="$row.Dest Port$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` src_ip=$row.Source|s$ dest_ip=$row.Dest IP|s$ dest_port=$row.Dest Port|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>
@@ -310,7 +310,7 @@
       <drilldown>
         <link>
           <![CDATA[
-            /app/SplunkforPaloAltoNetworks/search?q=`pan_wildfire` action="$click.value$"&earliest=$earliest$&latest=$latest$
+            /app/SplunkforPaloAltoNetworks/search?q=`pan_wildfire` action=$click.value|s$&earliest=$earliest$&latest=$latest$
 	  ]]>
         </link>
       </drilldown>


### PR DESCRIPTION
This patch converts usage of `key="$token$"` in dashboard drilldown links to use the correct [token filter syntax](http://docs.splunk.com/Documentation/Splunk/6.4.3/Viz/tokens#Token_filters). This allows values such as usernames like `domain\user` to be passed correctly to drilldown links/searches as `domain\\user` which doesn't get escaped correctly if you just surround the token in double quotes.