### PR TITLE
SaaS Overview dashboard fixes.

### DIFF
--- a/default/data/ui/views/saas_overview.xml
+++ b/default/data/ui/views/saas_overview.xml
@@ -122,7 +122,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` app=$click.name2|s$ [| stats count | eval latest = $click.value$ %2b 300 | fields latest] earliest = $click.value$
 	    ]]>
           </link>
         </drilldown>
@@ -133,7 +133,7 @@
         <title>SaaS Distribution</title>
         <search base="baseSearch">
           <query>
-            stats sparkline count sum(bytes) AS sbytes by app app:category app:subcategory | sort -sbytes | head 8 | eval "Vol in MB"=round(sbytes/1024/1024) | rename sparkline AS distribution | rename vsys AS VSYS | rename count as Sessions | table app app:category app:subcategory Sessions "Vol in MB" distribution
+            stats sparkline count sum(bytes) AS sbytes by app app:category app:subcategory | sort -sbytes | head 8 | eval "Vol in MB"=round(sbytes/1024/1024) | rename sparkline AS distribution, vsys AS VSYS, count as Sessions, app:category as app_category, app:subcategory as app_subcategory | table app app_category app_subcategory Sessions "Vol in MB" distribution
           </query>
         </search>
         <option name="wrap">true</option>
@@ -147,29 +147,29 @@
               /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$&earliest=$earliest$&latest=$latest$
           ]]>
           </link>
-          <link field="app:category">
+          <link field="app_category">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:category=$row.app:category|s$&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:category=$row.app_category|s$&earliest=$earliest$&latest=$latest$
             ]]>
           </link>
-          <link field="app:subcategory">
+          <link field="app_subcategory">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app:subcategory=$row.app_subcategory|s$&earliest=$earliest$&latest=$latest$
             ]]>
           </link>
           <link field="Sessions">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app:category|s$ app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app_category|s$ app:subcategory=$row.app_subcategory|s$&earliest=$earliest$&latest=$latest$
             ]]>
           </link>
           <link field="Vol in MB">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app:category|s$ app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app_category|s$ app:subcategory=$row.app_subcategory|s$&earliest=$earliest$&latest=$latest$
 	    ]]>
           </link>
           <link field="distribution">
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app:category|s$ app:subcategory=$row.app:subcategory|s$&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_logs` app=$row.app|s$ app:category=$row.app_category|s$ app_subcategory=$row.app_subcategory|s$&earliest=$earliest$&latest=$latest$
 	    ]]>
           </link>
         </drilldown>
@@ -339,7 +339,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas=yes app.category=$click.value$&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas=yes app:subcategory=$click.value$&earliest=$earliest$&latest=$latest$
 	        ]]>
           </link>
         </drilldown>
@@ -375,7 +375,7 @@
         <drilldown>
           <link>
             <![CDATA[
-              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas=yes app.category=$click.value$&earliest=$earliest$&latest=$latest$
+              /app/SplunkforPaloAltoNetworks/search?q=`pan_traffic` log_subtype=end app:is_saas=yes app:subcategory=$click.value$&earliest=$earliest$&latest=$latest$
 	        ]]>
           </link>
         </drilldown>


### PR DESCRIPTION
- SaaS usage panel had wrong field name in clickthru search.
- SaaS Distribution panel table column click throughs failed for any fields
  with a `:` in them. Renamed those fields to app_category and app_subcategory.
- SaaS Top Categories panels had the wrong field name in clickthru search.
