### PR TITLE
Modified to use serial_number instead of host

### DIFF
--- a/default/data/ui/views/overview.xml
+++ b/default/data/ui/views/overview.xml
@@ -3,7 +3,7 @@
   <description/>
   <search id="baseSearch">
     <query>
-      `pan_logs` | fillnull value="" | stats count by host sourcetype log_subtype action category
+      `pan_logs` | fillnull value="" | stats count by serial_number sourcetype log_subtype action category
     </query>
     <earliest>rt-5m</earliest>
     <latest>rt</latest>
@@ -12,7 +12,7 @@
     <single>
       <search base="baseSearch">
         <query>
-          stats dc(host)
+          stats dc(serial_number)
         </query>
       </search>
       <option name="underLabel">PAN Reporting</option>


### PR DESCRIPTION
Using the "serial_number" field instead of "host" for the overview dashboard. This is because when using a Panorama device to aggregate the logs and syslog them to Splunk, the host field is always the hostname of the Panorama device (unless you setup a custom index time transform). However, this was our solution as it required less changes overall and seemed to make sense logically for us, as all the logs are tagged with a serial_number. 